### PR TITLE
fix: rpi4 image should dynamically size to contents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -217,12 +217,15 @@ RUN <<-EOF
             mcopy -bsQ -i "${BOOT_IMG}" "${BOOT_DIR}"/* ::/
             rm -rf "${BOOT_DIR}"
 
-            ROOT_SIZE=$(du -csb . | tail -1 | cut -f1)
+            # calculate size of root disk
+            ROOT_SIZE=$(du -csk . | tail -1 | cut -f1)
+            ROOT_SIZE=$((ROOT_SIZE * 1024))
             ROOT_SIZE=$(((ROOT_SIZE + (ROOT_SIZE / 10)) / 512))
+
             ROOT_IMG="/tmp/root_partition.img"
-            echo "Creating ${ROOT_IMG} of ${ROOT_SIZE} blocks"
+            echo "Creating ${ROOT_IMG} of ${ROOT_SIZE} 512B blocks"
             fallocate -l $((ROOT_SIZE * 512)) "${ROOT_IMG}"
-            mke2fs -t ext4 -L K3OS_STATE -O ^orphan_file -d . "${ROOT_IMG}"
+            mke2fs -t ext4 -T default -L K3OS_STATE -O ^orphan_file -d . "${ROOT_IMG}"
             e2fsck -f -y "${ROOT_IMG}"
 
             FINAL_IMG="/output/k3os-rpi4-${TARGETARCH}.img"

--- a/Dockerfile
+++ b/Dockerfile
@@ -218,7 +218,7 @@ RUN <<-EOF
             rm -rf "${BOOT_DIR}"
 
             ROOT_SIZE=$(du -csb . | tail -1 | cut -f1)
-            ROOT_SIZE=$(((ROOT_SIZE * 1.1) / 512))
+            ROOT_SIZE=$(((ROOT_SIZE + (ROOT_SIZE / 10)) / 512))
             ROOT_IMG="/tmp/root_partition.img"
             echo "Creating ${ROOT_IMG} of ${ROOT_SIZE} blocks"
             fallocate -l $((ROOT_SIZE * 512)) "${ROOT_IMG}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -227,9 +227,7 @@ RUN <<-EOF
             fallocate -l $((ROOT_SIZE * 512)) "${ROOT_IMG}"
             mke2fs -t ext4 -T default -L K3OS_STATE -O ^orphan_file -d . "${ROOT_IMG}"
             e2fsck -f -y "${ROOT_IMG}"
-            debugfs "${ROOT_IMG}" <<-EOC
-            stat /
-            EOC
+            tune2fs -l "${ROOT_IMG}"
 
             FINAL_IMG="/output/k3os-rpi4-${TARGETARCH}.img"
             fallocate -l $(((2048 + BOOT_SIZE + ROOT_SIZE) * 512)) "${FINAL_IMG}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -227,6 +227,9 @@ RUN <<-EOF
             fallocate -l $((ROOT_SIZE * 512)) "${ROOT_IMG}"
             mke2fs -t ext4 -T default -L K3OS_STATE -O ^orphan_file -d . "${ROOT_IMG}"
             e2fsck -f -y "${ROOT_IMG}"
+            debugfs "${ROOT_IMG}" <<-EOC
+            stat /
+            EOC
 
             FINAL_IMG="/output/k3os-rpi4-${TARGETARCH}.img"
             fallocate -l $(((2048 + BOOT_SIZE + ROOT_SIZE) * 512)) "${FINAL_IMG}"

--- a/scripts/build
+++ b/scripts/build
@@ -10,6 +10,7 @@ if [ "${CI:-}" = "true" ]; then
 fi
 
 export DOCKER_BUILDKIT=1
+export BUILDKIT_PROGRESS=plain
 
 # Build k3os docker container
 echo "Building ${IMAGE_FQN}:${TAG}"
@@ -22,7 +23,6 @@ docker build \
     --build-arg "VERSION=${VERSION}" \
     --cache-from "${IMAGE_FQN}:${BRANCH}-${ARCH}" \
     --cache-from "${IMAGE_FQN}:${TAG}" \
-    --progress=plain \
     --target=image \
     --file "$(dirname $0)/../Dockerfile" \
     "$(dirname $0)/.."

--- a/scripts/package
+++ b/scripts/package
@@ -40,3 +40,5 @@ docker cp "${ID}:/output/k3os-rootfs-${ARCH}.tar.gz" "${DIST_DIR}"
 docker cp "${ID}:/output/k3os-vmlinuz-${ARCH}" "${DIST_DIR}"
 docker cp "${ID}:/output/sha256sum-${ARCH}.txt" "${DIST_DIR}"
 docker rm -fv "${ID}"
+
+ls -lFah "${DIST_DIR}"

--- a/scripts/package
+++ b/scripts/package
@@ -8,6 +8,9 @@ if [ "${CI:-}" = "true" ]; then
     CI_ARGS="--pull"
 fi
 
+export DOCKER_BUILDKIT=1
+export BUILDKIT_PROGRESS=plain
+
 # Collect build artifacts
 echo "Building ${IMAGE_FQN}-output:${TAG}"
 docker build \
@@ -16,7 +19,6 @@ docker build \
     --build-arg "K3S_VERSION=${K3S_VERSION}" \
     --build-arg "KERNEL_VERSION=${KERNEL_VERSION}" \
     --build-arg "VERSION=${VERSION}" \
-    --progress=plain \
     --target=output \
     --file "$(dirname $0)/../Dockerfile" \
     "$(dirname $0)/.."


### PR DESCRIPTION
Calculate the size of the root partition in the raspberry pi 4 image based on its contents

* Optimize image/iso construction by not untarring the rootfs needlessly
* Fix for docker build not having the --progress flag anymore
* Add some reporting on artifact sizes